### PR TITLE
feature: expose fetch entitlements error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planship/vue",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Planship SDK for Vue.js",
   "author": "pawel@planship.io",
   "license": "MIT",

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export interface IPlanshipCustomerContext<TEntitlements extends EntitlementsBase
   entitlements: ComputedRef<TEntitlements | Entitlements>
   fetchEntitlements: () => void
   isEntitlementsFetching: Ref<boolean>
+  fetchEntitlementsError?: Ref<Error | undefined>
   planshipCustomerApiClient: PlanshipCustomerApi
 }
 

--- a/src/usePlanshipCustomer.ts
+++ b/src/usePlanshipCustomer.ts
@@ -19,6 +19,8 @@ class PlanshipCustomerData {
 
   isEntitlementsFetching = ref(true)
 
+  fetchEntitlementsError = ref<Error | undefined>(undefined)
+
   entitlementsCallback(newEntitlements: Entitlements) {
     this.entitlementsDict.value = newEntitlements
   }
@@ -34,9 +36,9 @@ class PlanshipCustomerData {
       this.entitlementsDict.value = await this.planshipCustomerApiClient.getEntitlements(
         isServer ? undefined : this.entitlementsCallback.bind(this)
       )
+      this.fetchEntitlementsError.value = undefined
     } catch (e) {
-      console.error('Error fetching entitlements')
-      console.dir(e)
+      this.fetchEntitlementsError.value = e as Error
     } finally {
       this.isEntitlementsFetching.value = false
     }
@@ -54,6 +56,7 @@ class PlanshipCustomerData {
           : this.entitlementsDict.value
       ),
       isEntitlementsFetching: this.isEntitlementsFetching,
+      fetchEntitlementsError: this.fetchEntitlementsError,
       fetchEntitlements: this.fetchEntitlements.bind(this)
     }
   }


### PR DESCRIPTION
This PR, when merged, will expose the last error caught while fetching entitlements as fetchEntitlementsError property of the customer context object.